### PR TITLE
drift borks if your editor leaves backup files in the migrations directory

### DIFF
--- a/src/drift/core.clj
+++ b/src/drift/core.clj
@@ -114,7 +114,7 @@
   migration-namespaces []
   (if-let [migration-namespaces (:migration-namespaces (find-config))]
     (migration-namespaces (find-migrate-dir-name) (migrate-namespace-prefix))
-    (map namespace-string-for-file (loading-utils/all-class-path-file-names (migrate-namespace-dir)))))
+    (map namespace-string-for-file (filter #(re-matches #".*\.clj$" %) (loading-utils/all-class-path-file-names (migrate-namespace-dir))))))
 
 (defn
   migration-number-from-namespace [migration-namespace]


### PR DESCRIPTION
this patch filters the list of migrations files to *.clj files only, which removes any emacs ~ backups from consideration, and perhaps backup files from some other editors too
