### PR TITLE
Fix clojure Clojure 1.4 AOT problems by upgrading to Clojure 1.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject drift "1.4.5"
+(defproject drift "1.5.0"
   :description "Drift is a rails like migration framework for Clojure."
   :dependencies [[clojure-tools "1.2.0"]
                  [org.clojure/clojure "1.4.0"]


### PR DESCRIPTION
Hi macourtney, we came across failures of drift when running an AOT compiled project with it (these problems did not manifest until we deployed as such, worked fine in lein).

To test the solution, I pushed your snapshot clojure-tools to clojars under my name, and did the same for drift, using this 1.4-compatible version of clojure-tools (I also upgraded it to lein 2).  This solves our problems.

In this pull request I assume that a (non-snapshot) release of clojure-tools is done prior to acceptance.  I guessed you might version the next release of clojure-tools as 1.2.0 but you may decide this does not warrant a minor version bump so please let me know or edit as you will to reflect.  Thanks! --Rob
