### PR TITLE
Update migrate and create_migration to work right with lein 2

### DIFF
--- a/src/leiningen/create_migration.clj
+++ b/src/leiningen/create_migration.clj
@@ -4,7 +4,9 @@
 
 (defn create-migration [project & args]
   "Create a new migration file."
-  (eval-in-project project
+  (eval-in-project
+    (update-in project [:dependencies]
+      conj ['drift "1.4.5"])
     `(drift.generator/generate-migration-file ~(first args))
     '(require 'drift.generator)))
 

--- a/src/leiningen/migrate.clj
+++ b/src/leiningen/migrate.clj
@@ -4,6 +4,8 @@
 
 (defn migrate [project & args]
   "Run migration scripts."
-  (eval-in-project project
+  (eval-in-project
+    (update-in project [:dependencies]
+      conj ['drift "1.4.5"])
     `(drift.execute/run '~args)
     '(require 'drift.execute)))


### PR DESCRIPTION
Updated create_migration.clj and migrate.clj to work correctly with lein
2. Fixes #16.

The updates are explained here at https://groups.google.com/forum/?fromgroups=#!topic/leiningen/dUeYm0NsF08 and in the leiningen readme https://github.com/technomancy/leiningen/blob/master/doc/PLUGINS.md#code-evaluation.
