### PR TITLE
add a finished function to migration config, called after the action has...

### DIFF
--- a/src/drift/config.clj
+++ b/src/drift/config.clj
@@ -19,6 +19,7 @@
   {'current-version-fn :current-version
    'default-ns-content :ns-content
    'find-init-fn :init
+   'find-finished-fn :finished
    'find-migrate-dir-name :directory
    'find-src-dir :src
    'migration-namespaces :migration-namespaces

--- a/src/drift/core.clj
+++ b/src/drift/core.clj
@@ -12,6 +12,12 @@
   (when-let [init-fn (config/find-init-fn)]
     (init-fn args)))
 
+(defn run-finished
+  "runs the finished function"
+  []
+  (when-let [finished-fn (config/find-finished-fn)]
+    (finished-fn)))
+
 (defn with-init-config
   "run the init fn, merge results into config, then call the next function with that config
    bound to drift.config/*config-map*"
@@ -20,7 +26,9 @@
         init-config (if init-fn (init-fn args))]
     (config/with-config-map
       (merge (config/find-config) (if (map? init-config) init-config))
-      f)))
+      (fn []
+        (f)
+        (run-finished)))))
 
 (defn
 #^{:doc "Returns the directory where Conjure is running from."}

--- a/src/drift/generator.clj
+++ b/src/drift/generator.clj
@@ -42,7 +42,8 @@
         (let [migrate-directory (builder/find-or-create-migrate-directory)
               migration-file (builder/create-migration-file migrate-directory migration-name)] 
           (generate-file-content migration-file migration-name ns-content up-content down-content))
-        (migration-usage))))
+        (migration-usage))
+      (core/run-finished)))
 
 (defn generate-migration-file-cmdline
   "parse command-line args from lein, set up any custom config,

--- a/test/config/finished_config.clj
+++ b/test/config/finished_config.clj
@@ -1,0 +1,27 @@
+(ns config.finished-config
+  (:require [drift.builder :as builder]))
+
+(def version (atom nil))
+(def init-run? (atom false))
+(def finished-run? (atom false))
+
+(defn memory-current-version []
+  (or @version 0))
+
+(defn memory-update-version [new-version]
+  (swap! version #(identity %2) new-version))
+
+(defn init [args]
+  (compare-and-set! init-run? false true))
+
+(defn finished []
+  (compare-and-set! finished-run? false true))
+
+(defn migrate-config []
+  { :directory "/test/migrations"
+    :current-version memory-current-version
+    :update-version memory-update-version
+    :init init
+    :finished finished
+    :ns-content "\n  (:use clojure.contrib.sql)"
+    :migration-number-generator builder/incremental-migration-number-generator })

--- a/test/drift/test_execute.clj
+++ b/test/drift/test_execute.clj
@@ -2,6 +2,7 @@
   (:use clojure.test
         drift.execute)
   (:require [config.migrate-config :as config]
+            config.finished-config
             [test-helper :as test-helper]))
 
 (deftest test-version-number
@@ -51,3 +52,10 @@
                   (is (= 42 (:more-config drift.config/*config-map*))))]
 
     (run ["-version" "1234" "bloop" "-c" "config.dynamic-config/config" "blargh"])))
+
+(deftest test-finished-fn-called
+  []
+  (with-redefs [drift.runner/update-to-version (fn [version])]
+    (run ["-version" "1234" "bloop" "-c" "config.finished-config/migrate-config" "blargh"])
+
+   (is (= @config.finished-config/finished-run? true))))

--- a/test/drift/test_generator.clj
+++ b/test/drift/test_generator.clj
@@ -1,7 +1,9 @@
 (ns drift.test-generator
   (:use clojure.test
         drift.generator
-        test-helper))
+        test-helper)
+  (:require config.finished-config
+            [drift.builder :as builder]))
 
 (deftest test-migration-usage
   (migration-usage))
@@ -17,3 +19,12 @@
 
     (generate-migration-file-cmdline
      ["-c" "foo.bar/baz" "blahblah"])))
+
+(deftest test-finished-fn-called
+  (with-redefs [builder/find-or-create-migrate-directory (fn [])
+                builder/create-migration-file (fn [dir fname])
+                drift.generator/generate-file-content (fn [migration-file migration-name ns-content up-content down-content])]
+
+    (generate-migration-file-cmdline ["-c" "config.finished-config/migrate-config" "blahblah"])
+
+    (is (= @config.finished-config/finished-run? true))))


### PR DESCRIPTION
... been run

if your database driver (looking at you datastax cql3 java driver) happens to start a non-daemon thread then the vm will hang after a drift create-migration or migrate has been run

this patch adds an optional 'finished' function to the migrate-config, which can be used to System/exit when necessary
