### PR TITLE
Typo fixed.

### DIFF
--- a/src/leiningen/create_migration.clj
+++ b/src/leiningen/create_migration.clj
@@ -8,5 +8,5 @@
   (eval-in-project
     (update-in project [:dependencies]
       conj ['drift drift-version/version])
-    `(drift.generator/generate-migration-file '~args)
+    `(drift.generator/generate-migration-file-cmdline '~args)
     '(require 'drift.generator)))


### PR DESCRIPTION
Merging pull-request https://github.com/macourtney/drift/commit/f9ed47fa3c2ac4d3687fc947816a776be10f5b66 caused a bug: instead of calling drift.generator/generate-migration-file-cmdline drift.generator/generate-migration-file was called.
