### PR TITLE
Fixes #37 - Gets ns files using migrations dir instead of classpath.

### DIFF
--- a/src/drift/core.clj
+++ b/src/drift/core.clj
@@ -112,9 +112,11 @@
     (migration-namespaces (config/find-migrate-dir-name) (migrate-namespace-prefix))))
 
 (defn default-migration-namespaces []
-  (map namespace-string-for-file
-       (filter #(re-matches #".*\.clj$" %)
-               (loading-utils/all-class-path-file-names (migrate-namespace-dir)))))
+  (->> (find-migrate-directory)
+       .listFiles
+       (map #(.getName ^File %))
+       (filter #(re-matches #".*\.clj$" %))
+       (map namespace-string-for-file)))
 
 (defn sort-migration-namespaces
   ([migration-namespaces] (sort-migration-namespaces migration-namespaces true))


### PR DESCRIPTION
The classpath is empty in Leiningen in newer versions of Java. However, the migrations directory is first found, then its name was used to look it up on the classpath. Instead of looking for the directory on the classpath, here we use the directory File directly.