### PR TITLE
Uses drift-config option in Leiningen project to set config-fn-symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ If you're using drift with lein2, you'll need to add it to the :plugins list in 
 To set your Drift migration directory, simply add a clojure file
 called "migrate_config.clj" to the directory "src/config".
 
+If you require using a different namespace and/or function name,
+this can be overridden on the command line or in the project configuration,
+see [Custom configuration namespace/function name](#custom-config-ns).
+
 Your migrate_config.clj file should look something like:
 
 ```clojure
@@ -176,6 +180,23 @@ To create a new migration file which you can then edit:
 
 ```bash
 $ lein create-migration <migration name>
+```
+
+<a name="custom-config-ns"></a>
+### Custom configuration namespace/function name
+
+You can use a different configuration namespace or function by setting it in the Leiningen project configuration:
+
+```clojure
+:drift-config my-config.space/my-config-fn
+```
+
+This can be set in a profile (e.g. separate functions for different profiles) or on the top level.
+
+Optionally you can specify the function on the command line:
+
+```bash
+$ lein migrate -config my-config.space/my-config-fn
 ```
 
 ## Calling Drift From Java

--- a/src/drift/execute.clj
+++ b/src/drift/execute.clj
@@ -29,11 +29,11 @@
       (runner/update-to-version (version-number version)))))
 
 (defn
-  run [args]
+  run [config-fn-symbol args]
   (let [[opts remaining] (args/parse-migrate-args args)]
     (if (empty? remaining)
       (config/with-config-fn-symbol
-        (:config opts)
+        (or (:config opts) config-fn-symbol)
         (fn []
           (migrate (:version opts) remaining)))
       (do (logging/error "Invalid arguments:" (string/join " " remaining))

--- a/src/drift/generator.clj
+++ b/src/drift/generator.clj
@@ -50,11 +50,11 @@
 (defn generate-migration-file-cmdline
   "parse command-line args from lein, set up any custom config,
    and invoke generate-migration-file"
-  [args]
+  [config-fn-symbol args]
   (let [[opts [migration-name & remaining]] (args/parse-create-migration-args args)]
     (if (empty? remaining)
       (config/with-config-fn-symbol
-        (:config opts)
+        (or (:config opts) config-fn-symbol)
         (fn []
           (generate-migration-file migration-name)))
       (do (logging/error "Invalid arguments:" (string/join " " remaining))

--- a/src/leiningen/create_migration.clj
+++ b/src/leiningen/create_migration.clj
@@ -5,8 +5,11 @@
 
 (defn create-migration [project & args]
   "Create a new migration file."
-  (eval-in-project
-    (update-in project [:dependencies]
-      conj ['drift drift-version/version])
-    `(drift.generator/generate-migration-file-cmdline '~args)
-    '(require 'drift.generator)))
+  (let [drift-config (-> project
+                         :drift-config
+                         (#(when % (symbol %))))]
+    (eval-in-project
+      (update-in project [:dependencies]
+                 conj ['drift drift-version/version])
+      `(drift.generator/generate-migration-file-cmdline '~drift-config '~args)
+      '(require 'drift.generator))))

--- a/src/leiningen/migrate.clj
+++ b/src/leiningen/migrate.clj
@@ -5,8 +5,11 @@
 
 (defn migrate [project & args]
   "Run migration scripts."
-  (eval-in-project
-    (update-in project [:dependencies]
-      conj ['drift drift-version/version])
-    `(drift.execute/run '~args)
-    '(require 'drift.execute)))
+  (let [drift-config (-> project
+                         :drift-config
+                         (#(when % (symbol %))))]
+    (eval-in-project
+      (update-in project [:dependencies]
+                 conj ['drift drift-version/version])
+      `(drift.execute/run '~drift-config '~args)
+      '(require 'drift.execute)))


### PR DESCRIPTION
This fixes #30, and adds information to the README on how to set the config namespace and function name.